### PR TITLE
Adding ability to define the cache size (default: 100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sequence.get('post_id').then(function (id) {
 
 The API is in the process of settling, but has not yet had sufficient real-world testing to be considered stable. Backwards-compatibility will be maintained if reasonable.
 
-### sequence.init(client, [options]) -> Promise
+### sequence.init(client, [options, [cacheSize]]) -> Promise
 
 Initialization should be called **once** during server startup.
 
@@ -74,6 +74,12 @@ Initialization should be called **once** during server startup.
 Pass the options accordingly to overwrite the defaults. These parameters are used to store and update documents that represent a sequence in the index `esIndex` of document type `esType`.
 
 The index is configured by `init` for optimal performance. Thus you must use this index for sequences only!
+
+`cacheSize` default to 100
+
+Pass the cacheSize accordingly to overwrite the default. This parameter is used to define the number of IDs cached in sequence.
+ 
+If you have multiple instance of es-sequence running on different server you will want to set cacheSize to 1 to avoid jumps in the sequence of IDs.
 
 #### Error Handling
 

--- a/test/spec/api.js
+++ b/test/spec/api.js
@@ -34,6 +34,8 @@ describe('The es-sequence API', function() {
     helpers.expectError(sequence.init({}), countdown);
     helpers.expectError(sequence.init({ indices: null }), countdown);
     helpers.expectError(sequence.init(function () {}), countdown);
+    helpers.expectError(sequence.init(esClient, null, "1"), countdown);
+    helpers.expectError(sequence.init(esClient, null, {}), countdown);
 
   });
 
@@ -45,6 +47,14 @@ describe('The es-sequence API', function() {
   it('should init without options', function (done) {
     // I do not expect the default "sequences" index not to be existing to be able to execute the tests on my test db.
     sequence.init(esClient)
+      .then(function () {
+          helpers.expectIndexToExist(esClient, 'sequences', true, done);
+      });
+  });
+
+  it('should init without options and a cacheSize', function (done) {
+    // I do not expect the default "sequences" index not to be existing to be able to execute the tests on my test db.
+    sequence.init(esClient, null, 10)
       .then(function () {
           helpers.expectIndexToExist(esClient, 'sequences', true, done);
       });


### PR DESCRIPTION
This needs to be overriden to 1 (kinda disabling caching) when using es-sequence on multiple servers to avoid sequence jumping back and forth.